### PR TITLE
refactor intrusive list

### DIFF
--- a/include/condy/detail/intrusive.hpp
+++ b/include/condy/detail/intrusive.hpp
@@ -34,13 +34,13 @@ struct DoubleLinkEntry {
     DoubleLinkEntry *prev = nullptr;
 };
 
-template <typename T, SingleLinkEntry T::*Member> class IntrusiveSingleList {
+class SingleLinkListImpl {
 public:
-    IntrusiveSingleList() = default;
-    IntrusiveSingleList(IntrusiveSingleList &&other) noexcept
+    SingleLinkListImpl() = default;
+    SingleLinkListImpl(SingleLinkListImpl &&other) noexcept
         : head_(std::exchange(other.head_, nullptr)),
           tail_(std::exchange(other.tail_, nullptr)) {}
-    IntrusiveSingleList &operator=(IntrusiveSingleList &&other) noexcept {
+    SingleLinkListImpl &operator=(SingleLinkListImpl &&other) noexcept {
         if (this != &other) {
             assert(empty());
             head_ = std::exchange(other.head_, nullptr);
@@ -49,14 +49,11 @@ public:
         return *this;
     }
 
-    CONDY_DELETE_COPY(IntrusiveSingleList);
+    CONDY_DELETE_COPY(SingleLinkListImpl);
 
-public:
-    void push_back(T *item) noexcept {
-        assert(item != nullptr);
-        SingleLinkEntry *entry = &(item->*Member);
+    void push_back(SingleLinkEntry *entry) noexcept {
+        assert(entry != nullptr);
         assert(entry->next == nullptr);
-        entry->next = nullptr;
         if (!head_) {
             head_ = entry;
             tail_ = entry;
@@ -66,7 +63,7 @@ public:
         }
     }
 
-    void push_back(IntrusiveSingleList other) noexcept {
+    void push_back(SingleLinkListImpl &other) noexcept {
         if (other.empty()) {
             return;
         }
@@ -77,11 +74,13 @@ public:
             tail_->next = other.head_;
             tail_ = other.tail_;
         }
+        other.head_ = nullptr;
+        other.tail_ = nullptr;
     }
 
     bool empty() const noexcept { return head_ == nullptr; }
 
-    T *pop_front() noexcept {
+    SingleLinkEntry *pop_front() noexcept {
         if (empty()) {
             return nullptr;
         }
@@ -91,7 +90,7 @@ public:
             tail_ = nullptr;
         }
         entry->next = nullptr;
-        return container_of(Member, entry);
+        return entry;
     }
 
 private:
@@ -99,13 +98,13 @@ private:
     SingleLinkEntry *tail_ = nullptr;
 };
 
-template <typename T, DoubleLinkEntry T::*Member> class IntrusiveDoubleList {
+class DoubleLinkListImpl {
 public:
-    IntrusiveDoubleList() = default;
-    IntrusiveDoubleList(IntrusiveDoubleList &&other) noexcept
+    DoubleLinkListImpl() = default;
+    DoubleLinkListImpl(DoubleLinkListImpl &&other) noexcept
         : head_(std::exchange(other.head_, nullptr)),
           tail_(std::exchange(other.tail_, nullptr)) {}
-    IntrusiveDoubleList &operator=(IntrusiveDoubleList &&other) noexcept {
+    DoubleLinkListImpl &operator=(DoubleLinkListImpl &&other) noexcept {
         if (this != &other) {
             assert(empty());
             head_ = std::exchange(other.head_, nullptr);
@@ -114,12 +113,10 @@ public:
         return *this;
     }
 
-    CONDY_DELETE_COPY(IntrusiveDoubleList);
+    CONDY_DELETE_COPY(DoubleLinkListImpl);
 
-public:
-    void push_back(T *item) noexcept {
-        assert(item != nullptr);
-        DoubleLinkEntry *entry = &(item->*Member);
+    void push_back(DoubleLinkEntry *entry) noexcept {
+        assert(entry != nullptr);
         assert(entry->next == nullptr && entry->prev == nullptr);
         entry->next = nullptr;
         entry->prev = tail_;
@@ -134,7 +131,7 @@ public:
 
     bool empty() const noexcept { return head_ == nullptr; }
 
-    T *pop_front() noexcept {
+    DoubleLinkEntry *pop_front() noexcept {
         if (empty()) {
             return nullptr;
         }
@@ -147,12 +144,11 @@ public:
         }
         entry->next = nullptr;
         entry->prev = nullptr;
-        return container_of(Member, entry);
+        return entry;
     }
 
-    bool remove(T *item) noexcept {
-        assert(item != nullptr);
-        DoubleLinkEntry *entry = &(item->*Member);
+    bool remove(DoubleLinkEntry *entry) noexcept {
+        assert(entry != nullptr);
         if (entry->prev == nullptr && entry->next == nullptr &&
             head_ != entry) {
             return false;
@@ -177,6 +173,42 @@ public:
 private:
     DoubleLinkEntry *head_ = nullptr;
     DoubleLinkEntry *tail_ = nullptr;
+};
+
+template <typename T, SingleLinkEntry T::*Member> class IntrusiveSingleList {
+public:
+    void push_back(T *item) noexcept { impl_.push_back(&(item->*Member)); }
+
+    void push_back(IntrusiveSingleList other) noexcept {
+        impl_.push_back(other.impl_);
+    }
+
+    bool empty() const noexcept { return impl_.empty(); }
+
+    T *pop_front() noexcept {
+        SingleLinkEntry *entry = impl_.pop_front();
+        return entry ? container_of(Member, entry) : nullptr;
+    }
+
+private:
+    SingleLinkListImpl impl_;
+};
+
+template <typename T, DoubleLinkEntry T::*Member> class IntrusiveDoubleList {
+public:
+    void push_back(T *item) noexcept { impl_.push_back(&(item->*Member)); }
+
+    bool empty() const noexcept { return impl_.empty(); }
+
+    T *pop_front() noexcept {
+        DoubleLinkEntry *entry = impl_.pop_front();
+        return entry ? container_of(Member, entry) : nullptr;
+    }
+
+    bool remove(T *item) noexcept { return impl_.remove(&(item->*Member)); }
+
+private:
+    DoubleLinkListImpl impl_;
 };
 
 } // namespace detail


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored intrusive list to separate implementation from type-safe wrapper

- Extracted `SingleLinkListImpl` and `DoubleLinkListImpl` as non-template base classes

- Moved template logic into new `IntrusiveSingleList` and `IntrusiveDoubleList` wrappers

- Updated `splice` method to clear source list after moving entries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IntrusiveSingleList<T, Member>"] --> B["SingleLinkListImpl"]
  C["IntrusiveDoubleList<T, Member>"] --> D["DoubleLinkListImpl"]
  B -- "push_back, pop_front, splice" --> E["SingleLinkEntry"]
  D -- "push_back, pop_front, remove" --> F["DoubleLinkEntry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>intrusive.hpp</strong><dd><code>Refactored intrusive list into impl and wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/condy/detail/intrusive.hpp

<ul><li>Extracted <code>SingleLinkListImpl</code> and <code>DoubleLinkListImpl</code> as non-template <br>classes<br> <li> Created new template wrappers <code>IntrusiveSingleList</code> and <br><code>IntrusiveDoubleList</code><br> <li> Updated <code>splice</code> to clear source list after moving entries<br> <li> Changed <code>push_back</code>, <code>pop_front</code>, and <code>remove</code> to accept raw entry pointers</ul>


</details>


  </td>
  <td><a href="https://github.com/condy-cpp/condy/pull/150/files#diff-0887186c94b919012226ed2e93507c10da2efa2ff085ec1d878dc23e651c8c92">+89/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

